### PR TITLE
🐛 Source Bing Ads : fix rollback window for marketing performance reports

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/reports.py
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/reports.py
@@ -203,11 +203,7 @@ class ReportsMixin(ABC):
     def request_params(
         self, stream_state: Mapping[str, Any] = None, account_id: str = None, **kwargs: Mapping[str, Any]
     ) -> Mapping[str, Any]:
-        if not stream_state or not account_id or not stream_state.get(account_id, {}).get(self.cursor_field):
-            start_date = self.client.reports_start_date
-        else:
-            # gets starting point for a stream and account
-            start_date = pendulum.from_timestamp(stream_state[account_id][self.cursor_field])
+        start_date = self._get_start_date(stream_state, account_id)
 
         reporting_service = self.client.get_service("ReportingService")
         request_time_zone = reporting_service.factory.create("ReportTimeZone")
@@ -227,6 +223,14 @@ class ReportsMixin(ABC):
             "overwrite_result_file": True,
             "timeout_in_milliseconds": self.timeout,
         }
+
+    def _get_start_date(self, stream_state: Mapping[str, Any] = None, account_id: str = None):
+        if not stream_state or not account_id or not stream_state.get(account_id, {}).get(self.cursor_field):
+            start_date = self.client.reports_start_date
+        else:
+            # gets starting point for a stream and account
+            start_date = pendulum.from_timestamp(stream_state[account_id][self.cursor_field])
+        return start_date
 
     def get_updated_state(
         self,
@@ -337,3 +341,14 @@ class ReportsMixin(ABC):
             yield {"account_id": account["Id"], "customer_id": account["ParentCustomerId"]}
 
         yield from []
+
+
+class PerformanceReportsMixin(ReportsMixin):
+
+    def _get_start_date(self, stream_state: Mapping[str, Any] = None, account_id: str = None):
+        if not stream_state or not account_id or not stream_state.get(account_id, {}).get(self.cursor_field):
+            start_date = self.client.reports_start_date - pendulum.duration(days=self.config["lookback_window"])
+        else:
+            # gets starting point for a stream and account
+            start_date = pendulum.from_timestamp(stream_state[account_id][self.cursor_field]) - pendulum.duration(days=self.config["lookback_window"])
+        return start_date

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/reports.py
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/reports.py
@@ -347,8 +347,8 @@ class PerformanceReportsMixin(ReportsMixin):
 
     def _get_start_date(self, stream_state: Mapping[str, Any] = None, account_id: str = None):
         if not stream_state or not account_id or not stream_state.get(account_id, {}).get(self.cursor_field):
-            start_date = self.client.reports_start_date - pendulum.duration(days=self.config["lookback_window"])
+            start_date = self.client.reports_start_date.subtract(days=self.config["lookback_window"])
         else:
             # gets starting point for a stream and account
-            start_date = pendulum.from_timestamp(stream_state[account_id][self.cursor_field]) - pendulum.duration(days=self.config["lookback_window"])
+            start_date = pendulum.from_timestamp(stream_state[account_id][self.cursor_field]).subtract(days=self.config["lookback_window"])
         return start_date

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/source.py
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/source.py
@@ -24,6 +24,7 @@ from source_bing_ads.reports import (
     LOW_QUALITY_FIELDS,
     REVENUE_FIELDS,
     ReportsMixin,
+    PerformanceReportsMixin,
 )
 from suds import sudsobject
 
@@ -343,7 +344,7 @@ class BudgetSummaryReport(ReportsMixin, BingAdsStream):
     ]
 
 
-class CampaignPerformanceReport(ReportsMixin, BingAdsStream):
+class CampaignPerformanceReport(PerformanceReportsMixin, BingAdsStream):
     data_field: str = ""
     service_name: str = "ReportingService"
     report_name: str = "CampaignPerformanceReport"
@@ -424,7 +425,7 @@ class CampaignPerformanceReportMonthly(CampaignPerformanceReport):
     ]
 
 
-class AdPerformanceReport(ReportsMixin, BingAdsStream):
+class AdPerformanceReport(PerformanceReportsMixin, BingAdsStream):
     data_field: str = ""
     service_name: str = "ReportingService"
     report_name: str = "AdPerformanceReport"
@@ -492,7 +493,7 @@ class AdPerformanceReportMonthly(AdPerformanceReport):
     report_aggregation = "Monthly"
 
 
-class AdGroupPerformanceReport(ReportsMixin, BingAdsStream):
+class AdGroupPerformanceReport(PerformanceReportsMixin, BingAdsStream):
     data_field: str = ""
     service_name: str = "ReportingService"
     report_name: str = "AdGroupPerformanceReport"
@@ -574,7 +575,7 @@ class AdGroupPerformanceReportMonthly(AdGroupPerformanceReport):
     ]
 
 
-class KeywordPerformanceReport(ReportsMixin, BingAdsStream):
+class KeywordPerformanceReport(PerformanceReportsMixin, BingAdsStream):
     data_field: str = ""
     service_name: str = "ReportingService"
     report_name: str = "KeywordPerformanceReport"
@@ -656,7 +657,7 @@ class KeywordPerformanceReportMonthly(KeywordPerformanceReport):
     report_aggregation = "Monthly"
 
 
-class AccountPerformanceReport(ReportsMixin, BingAdsStream):
+class AccountPerformanceReport(PerformanceReportsMixin, BingAdsStream):
     data_field: str = ""
     service_name: str = "ReportingService"
     report_name: str = "AccountPerformanceReport"

--- a/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/spec.json
+++ b/airbyte-integrations/connectors/source-bing-ads/source_bing_ads/spec.json
@@ -60,6 +60,15 @@
         "default": "2020-01-01",
         "description": "The start date from which to begin replicating report data. Any data generated before this date will not be replicated in reports. This is a UTC date in YYYY-MM-DD format.",
         "order": 5
+      },
+      "lookback_window": {
+        "title": "Lookback window",
+        "description": "Also known as attribution or conversion window. How far into the past to look for records (in days). If your conversion window has a hours/minutes granularity, round it up to the number of days exceeding.\nUsed only in performance report streams with incremental mode.",
+        "type": "integer",
+        "default": 0,
+        "minimum": 0,
+        "maximum": 90,
+        "order": 6
       }
     }
   },

--- a/airbyte-integrations/connectors/source-bing-ads/unit_tests/test_reports.py
+++ b/airbyte-integrations/connectors/source-bing-ads/unit_tests/test_reports.py
@@ -38,6 +38,14 @@ def test_get_column_value():
     assert test_report.get_column_value(record, "Spend") == 1.203
 
 
+def test_get_updated_state_init_state():
+    test_report = TestReport()
+    stream_state = {}
+    latest_record = {"AccountId": 123, "Time": "2020-01-02"}
+    new_state = test_report.get_updated_state(stream_state, latest_record)
+    assert new_state["123"]["Time"] == (pendulum.parse("2020-01-02")).timestamp()
+
+
 def test_get_updated_state_new_state():
     test_report = TestReport()
     stream_state = {"123": {"Time": pendulum.parse("2020-01-01").timestamp()}}


### PR DESCRIPTION
## What
Bing Ads connector doesn’t ingest all **conversions** for marketing performance reports. There are discrepancies between Bing UI data and data received in the Destination.

At the moment, the conversions' fields (_Conversions_, _AllConversions_, _ConversionsQualified_) in the Destination only count conversions that happened the day of the click. Conversions happening after 2+ days, during the attribution window, are not counted.

The problem comes from the connector **cursor field** (on the incremental sync) not being appropriately implemented. Indeed, it misses a **rollback window** to attribute conversions happening after 2+ days.

More on this [issue](https://github.com/airbytehq/airbyte/issues/22930).

This PR intends to add an optional parameter `lookback_window`in the connector configuration, for performance reports ingested with incremental streams.

## How
During a sync, instead of retrieving data from `[cursor_value, now()]`, we’ll retrieve data from `[cursor_value - rollback_window, now()]`. So the API call logic is modified (not the cursor logic).

This means that if the cursor value is set to 15/12/2022, we’ll retrieve data up to 15/11/2022 (for a 30-day attribution window).

Cons: we’ll ingest lots of duplicates in the history table (30 duplicates per record in most cases!). The `deduped + history` feature will handle the deduplication in the final table.

## Recommended reading order
Review per commit, in chronological order.

## 🚨 User Impact 🚨
No breaking changes as the `lookback_window` is an optional parameter.

## Pre-merge Checklist

<details><summary><strong>Updating a connector</strong></summary>

### Community member or Airbyter

- [ ] Grant edit access to maintainers ([instructions](https://docs.github.com/en/github/collaborating-with-pull-requests/working-with-forks/allowing-changes-to-a-pull-request-branch-created-from-a-fork#enabling-repository-maintainer-permissions-on-existing-pull-requests))
- [x] Secrets in the connector's spec are annotated with `airbyte_secret`
- [ ] Unit & integration tests added and passing. Community members, please provide proof of success locally e.g: screenshot or copy-paste unit, integration, and acceptance test output. To run acceptance tests for a Python connector, follow instructions in the README. For java connectors run `./gradlew :airbyte-integrations:connectors:<name>:integrationTest`.
- [ ] Code reviews completed
- [ ] Documentation updated
    - [ ] Connector's `README.md`
    - [ ] Connector's `bootstrap.md`. See [description and examples](https://docs.google.com/document/d/1ypdgmwmEHWv-TrO4_YOQ7pAJGVrMp5BOkEVh831N260/edit?usp=sharing)
    - [ ] Changelog updated in `docs/integrations/<source or destination>/<name>.md` including changelog. See changelog [example](https://docs.airbyte.io/integrations/sources/stripe#changelog)
- [ ] PR name follows [PR naming conventions](https://docs.airbyte.com/contributing-to-airbyte/issues-and-pull-requests)

</details>